### PR TITLE
Remove PHP extensions from URLs

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -1,0 +1,26 @@
+RewriteEngine On
+
+# Alt klasörde çalışıyorsan örn: /campro/
+#RewriteBase /campro/
+
+# MultiViews çakışmalarını engelle
+Options -MultiViews
+
+# Varsayılan giriş
+DirectoryIndex index.php
+
+# .php ile gelen istekleri uzantısız eşdeğerine 301 yönlendir (kanonik)
+RewriteCond %{THE_REQUEST} \s/+(.+)\.php(\s|\?) [NC]
+RewriteRule ^ %1 [R=301,L]
+
+# İstenen path gerçek dosya/klasörse dokunma
+RewriteCond %{REQUEST_FILENAME} -f [OR]
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^ - [L]
+
+# Uzantısız istek için karşılık .php dosyası varsa iç yönlendirme yap
+RewriteCond %{REQUEST_FILENAME}.php -f
+RewriteRule ^(.+)$ $1.php [L,QSA]
+
+# /index için kanonik: /'a yönlendir
+RewriteRule ^index$ / [R=301,L]

--- a/dashboard.php
+++ b/dashboard.php
@@ -384,11 +384,11 @@ foreach ($orders as $o) {
                                 <td><?php echo htmlspecialchars($o['delivery']); ?></td>
                                 <td>
                                     <div class='btn-group' role='group'>
-                                        <a href='order_view.php?id=<?php echo urlencode((string)$o['id']); ?>' 
+                                        <a href="<?= url('order_view') ?>?id=<?php echo urlencode((string)$o['id']); ?>"
                                            class='btn btn-outline-primary btn-sm'>
                                             <i class='fas fa-eye'></i>
                                         </a>
-                                        <a href='order_edit.php?id=<?php echo urlencode((string)$o['id']); ?>' 
+                                        <a href="<?= url('order_edit') ?>?id=<?php echo urlencode((string)$o['id']); ?>"
                                            class='btn btn-outline-secondary btn-sm'>
                                             <i class='fas fa-edit'></i>
                                         </a>
@@ -404,7 +404,7 @@ foreach ($orders as $o) {
                     <i class='fas fa-inbox icon'></i>
                     <h4>Henüz sipariş bulunmuyor</h4>
                     <p>İlk siparişinizi oluşturmak için siparişler sayfasını ziyaret edin.</p>
-                    <a href='siparisler.php' class='btn btn-primary mt-3'>
+                    <a href="<?= url('siparisler') ?>" class='btn btn-primary mt-3'>
                         <i class='fas fa-plus me-2'></i>
                         Yeni Sipariş Oluştur
                     </a>
@@ -424,25 +424,25 @@ foreach ($orders as $o) {
                     </h5>
                     <div class='row g-3'>
                         <div class='col-6 col-md-3'>
-                            <a href='siparisler.php' class='btn btn-outline-primary w-100'>
+                            <a href="<?= url('siparisler') ?>" class='btn btn-outline-primary w-100'>
                                 <i class='fas fa-plus-circle d-block mb-2' style='font-size: 1.5rem;'></i>
                                 Yeni Sipariş
                             </a>
                         </div>
                         <div class='col-6 col-md-3'>
-                            <a href='musteriler.php' class='btn btn-outline-success w-100'>
+                            <a href="<?= url('musteriler') ?>" class='btn btn-outline-success w-100'>
                                 <i class='fas fa-user-plus d-block mb-2' style='font-size: 1.5rem;'></i>
                                 Yeni Müşteri
                             </a>
                         </div>
                         <div class='col-6 col-md-3'>
-                            <a href='urunler.php' class='btn btn-outline-info w-100'>
+                            <a href="<?= url('urunler') ?>" class='btn btn-outline-info w-100'>
                                 <i class='fas fa-wine-glass d-block mb-2' style='font-size: 1.5rem;'></i>
                                 Ürün Ekle
                             </a>
                         </div>
                         <div class='col-6 col-md-3'>
-                            <a href='fiyat-listesi.php' class='btn btn-outline-warning w-100'>
+                            <a href="<?= url('fiyat-listesi') ?>" class='btn btn-outline-warning w-100'>
                                 <i class='fas fa-tags d-block mb-2' style='font-size: 1.5rem;'></i>
                                 Fiyat Güncelle
                             </a>

--- a/header.php
+++ b/header.php
@@ -1,4 +1,5 @@
 <?php
+require_once __DIR__ . '/helpers.php';
 session_start();
 if (empty($_SESSION['csrf_token'])) {
   $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
@@ -200,12 +201,12 @@ $hasLogo = file_exists($logoFile);
   <nav class='navbar navbar-expand-lg'>
     <div class='container'>
       <?php if ($hasLogo): ?>
-        <a class='navbar-brand' href='dashboard.php'>
+        <a class='navbar-brand' href="<?= url('dashboard') ?>">
           <img src='/assets/logo.svg' alt='<?php echo htmlspecialchars('Cam Takip'); ?>' height='35' class='me-2'>
           Cam Takip
         </a>
       <?php else: ?>
-        <a class='navbar-brand' href='dashboard.php'>
+        <a class='navbar-brand' href="<?= url('dashboard') ?>">
           <i class='fas fa-wine-glass me-2'></i>
           Cam Takip
         </a>
@@ -219,37 +220,37 @@ $hasLogo = file_exists($logoFile);
       <div class='collapse navbar-collapse' id='mainNavbar'>
         <ul class='navbar-nav me-auto mb-2 mb-lg-0'>
           <li class='nav-item'>
-            <a class='nav-link' href='dashboard.php'>
+            <a class='nav-link' href="<?= url('dashboard') ?>">
               <i class='fas fa-tachometer-alt me-1'></i>
               Panel
             </a>
           </li>
           <li class='nav-item'>
-            <a class='nav-link' href='tedarikciler.php'>
+            <a class='nav-link' href="<?= url('tedarikciler') ?>">
               <i class='fas fa-truck me-1'></i>
               Tedarikçiler
             </a>
           </li>
           <li class='nav-item'>
-            <a class='nav-link' href='musteriler.php'>
+            <a class='nav-link' href="<?= url('musteriler') ?>">
               <i class='fas fa-users me-1'></i>
               Müşteriler
             </a>
           </li>
           <li class='nav-item'>
-            <a class='nav-link' href='urunler.php'>
+            <a class='nav-link' href="<?= url('urunler') ?>">
               <i class='fas fa-wine-glass me-1'></i>
               Ürünler
             </a>
           </li>
           <li class='nav-item'>
-            <a class='nav-link' href='fiyat-listesi.php'>
+            <a class='nav-link' href="<?= url('fiyat-listesi') ?>">
               <i class='fas fa-list-alt me-1'></i>
               Fiyat Listesi
             </a>
           </li>
           <li class='nav-item'>
-            <a class='nav-link' href='siparisler.php'>
+            <a class='nav-link' href="<?= url('siparisler') ?>">
               <i class='fas fa-shopping-cart me-1'></i>
               Siparişler
             </a>
@@ -265,20 +266,20 @@ $hasLogo = file_exists($logoFile);
             </a>
             <ul class='dropdown-menu dropdown-menu-end' aria-labelledby='userDropdown'>
               <li>
-                <a class='dropdown-item' href='profile.php'>
+                <a class='dropdown-item' href="<?= url('profile') ?>">
                   <i class='fas fa-user me-2'></i>
                   Profil
                 </a>
               </li>
               <li>
-                <a class='dropdown-item' href='settings.php'>
+                <a class='dropdown-item' href="<?= url('settings') ?>">
                   <i class='fas fa-cog me-2'></i>
                   Ayarlar
                 </a>
               </li>
               <li><hr class='dropdown-divider'></li>
               <li>
-                <form method='post' action='logout.php' class='d-inline'>
+                <form method='post' action="<?= url('logout') ?>" class='d-inline'>
                   <?php if ($csrfToken !== ''): ?>
                     <input type='hidden' name='csrf_token' value='<?php echo htmlspecialchars($csrfToken); ?>'>
                   <?php endif; ?>

--- a/helpers.php
+++ b/helpers.php
@@ -1,0 +1,12 @@
+<?php
+function base_path(): string {
+    // Uygulama alt klasördeyse (örn. /campro), buraya '/campro' yaz.
+    return '';
+}
+
+function url(string $path = ''): string {
+    $base = rtrim(base_path(), '/');
+    $path = ltrim($path, '/');
+    return $base . '/' . $path;
+}
+

--- a/index.php
+++ b/index.php
@@ -1,3 +1,4 @@
+<?php require_once __DIR__ . '/helpers.php'; ?>
 <!DOCTYPE html>
 <html lang="tr">
 
@@ -260,11 +261,11 @@
                                 </div>
                                 
                                 <div class="buttons-container">
-                                    <a href="login.php" class="btn btn-custom-primary">
+                                    <a href="<?= url('login') ?>" class="btn btn-custom-primary">
                                         <i class="fas fa-sign-in-alt me-2"></i>
                                         Oturum Aç
                                     </a>
-                                    <a href="register.php" class="btn btn-custom-secondary">
+                                    <a href="<?= url('register') ?>" class="btn btn-custom-secondary">
                                         <i class="fas fa-user-plus me-2"></i>
                                         Kayıt Ol
                                     </a>

--- a/login.php
+++ b/login.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once 'config.php';
+require_once __DIR__ . '/helpers.php';
 
 // Remember me çerezi varsa kullanıcıyı panele yönlendir
 if (isset($_COOKIE['rememberme'])) {
@@ -23,7 +24,7 @@ if (isset($_COOKIE['rememberme'])) {
             $stmt->close();
         }
     }
-    header('Location: dashboard.php');
+    header('Location: ' . url('dashboard'));
     exit();
 }
 
@@ -57,7 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         setcookie('rememberme', '', time() - 3600, '/');
                     }
 
-                    header('Location: dashboard.php');
+                    header('Location: ' . url('dashboard'));
                     exit();
                 } else {
                     $error = 'Kullanıcı adı veya parola yanlış.';
@@ -318,7 +319,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 
 <body>
-    <a href="index.php" class="back-to-home">
+    <a href="<?= url('') ?>" class="back-to-home">
         <i class="fas fa-arrow-left me-2"></i>
         Ana Sayfaya Dön
     </a>
@@ -344,7 +345,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             </div>
                         <?php endif; ?>
 
-                        <form method="post" action="">
+                        <form method="post" action="<?= url('login') ?>">
                             <div class="mb-3">
                                 <label for="username" class="form-label">
                                     <i class="fas fa-user me-2"></i>
@@ -382,7 +383,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <div class="card-footer">
                         <p class="mb-0">
                             Hesabınız yok mu?
-                            <a href="register.php">
+                            <a href="<?= url('register') ?>">
                                 <i class="fas fa-user-plus me-1"></i>
                                 Kayıt olun
                             </a>

--- a/logout.php
+++ b/logout.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once __DIR__ . '/helpers.php';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     $token = $_POST['csrf_token'] ?? '';
@@ -21,6 +22,6 @@ session_destroy();
 
 setcookie('rememberme', '', time() - 3600, '/');
 
-header('Location: login.php');
+header('Location: ' . url('login'));
 exit;
 ?>

--- a/register.php
+++ b/register.php
@@ -1,5 +1,6 @@
 <?php
 require_once 'config.php';
+require_once __DIR__ . '/helpers.php';
 
 $success = '';
 $error = '';
@@ -18,7 +19,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $stmt->bind_param('sssss', $firstname, $lastname, $username, $email, $hash);
             try {
                 $stmt->execute();
-                header('Location: login.php');
+                header('Location: ' . url('login'));
                 exit;
             } catch (mysqli_sql_exception $e) {
                 if ($e->getCode() === 1062) {
@@ -275,7 +276,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 </head>
 
 <body>
-    <a href="index.php" class="back-to-home">
+    <a href="<?= url('') ?>" class="back-to-home">
         <i class="fas fa-arrow-left me-2"></i>
         Ana Sayfaya Dön
     </a>
@@ -301,7 +302,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             </div>
                         <?php endif; ?>
 
-                        <form method="post" action="">
+                        <form method="post" action="<?= url('register') ?>">
                             <div class="row-cols-custom mb-3">
                                 <div>
                                     <label for="firstname" class="form-label">
@@ -353,7 +354,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     <div class="card-footer">
                         <p class="mb-0">
                             Zaten hesabınız var mı?
-                            <a href="login.php">
+                            <a href="<?= url('login') ?>">
                                 <i class="fas fa-sign-in-alt me-1"></i>
                                 Giriş yapın
                             </a>


### PR DESCRIPTION
## Summary
- Add rewrite rules to serve PHP pages without extensions
- Introduce reusable `url()` helper and update navigation links, forms, and redirects
- Redirect legacy `.php` requests and adjust dashboard links to new routes

## Testing
- `php -l header.php index.php login.php register.php dashboard.php logout.php helpers.php`


------
https://chatgpt.com/codex/tasks/task_e_68bad6ec79c08328844eb1f5dcbcc8b4