### PR TITLE
Add supplier and contact management

### DIFF
--- a/api/contacts/delete.php
+++ b/api/contacts/delete.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+session_start();
+header('Content-Type: application/json');
+
+function json_exit($ok, $message = '') {
+    echo json_encode(['ok' => $ok, 'message' => $message]);
+    exit;
+}
+
+$csrf = $_POST['csrf'] ?? '';
+if ($csrf === '' || !isset($_SESSION['csrf_token']) || $csrf !== $_SESSION['csrf_token']) {
+    json_exit(false, 'Geçersiz oturum');
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if ($id <= 0) {
+    json_exit(false, 'Geçersiz ID');
+}
+
+$stmt = $conn->prepare('UPDATE supplier_contacts SET is_active=0 WHERE id=?');
+$stmt->bind_param('i', $id);
+$ok = $stmt->execute();
+$stmt->close();
+
+json_exit($ok, $ok ? 'Silindi' : 'Silinemedi');

--- a/api/contacts/list.php
+++ b/api/contacts/list.php
@@ -1,0 +1,35 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+session_start();
+header('Content-Type: application/json');
+
+function json_exit($ok, $data = null, $message = '') {
+    echo json_encode(['ok' => $ok, 'data' => $data, 'message' => $message]);
+    exit;
+}
+
+$supplier_id = (int)($_GET['supplier_id'] ?? 0);
+if ($supplier_id <= 0) {
+    json_exit(false, null, 'Geçersiz supplier_id');
+}
+
+$page = max(1, (int)($_GET['page'] ?? 1));
+$per_page = max(1, min(100, (int)($_GET['per_page'] ?? 10)));
+$offset = ($page - 1) * $per_page;
+
+$total = 0;
+$stmt = $conn->prepare('SELECT COUNT(*) FROM supplier_contacts WHERE supplier_id=? AND is_active=1');
+$stmt->bind_param('i', $supplier_id);
+$stmt->execute();
+$stmt->bind_result($total);
+$stmt->fetch();
+$stmt->close();
+
+$stmt = $conn->prepare('SELECT * FROM supplier_contacts WHERE supplier_id=? AND is_active=1 ORDER BY full_name ASC LIMIT ?, ?');
+$stmt->bind_param('iii', $supplier_id, $offset, $per_page);
+$stmt->execute();
+$result = $stmt->get_result();
+$rows = $result->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+json_exit(true, ['rows' => $rows, 'total' => $total]);

--- a/api/contacts/save.php
+++ b/api/contacts/save.php
@@ -1,0 +1,71 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+session_start();
+header('Content-Type: application/json');
+
+function json_exit($ok, $message = '', $extra = []) {
+    echo json_encode(array_merge(['ok' => $ok, 'message' => $message], $extra));
+    exit;
+}
+
+$csrf = $_POST['csrf'] ?? '';
+if ($csrf === '' || !isset($_SESSION['csrf_token']) || $csrf !== $_SESSION['csrf_token']) {
+    json_exit(false, 'Geçersiz oturum');
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$supplier_id = (int)($_POST['supplier_id'] ?? 0);
+$full_name = trim($_POST['full_name'] ?? '');
+$role = trim($_POST['role'] ?? 'Satın Alma Görevlisi');
+$phone = trim($_POST['phone'] ?? '');
+$email = trim($_POST['email'] ?? '');
+$notes = trim($_POST['notes'] ?? '');
+$is_primary = isset($_POST['is_primary']) ? 1 : 0;
+$is_active = isset($_POST['is_active']) ? 1 : 0;
+
+$errors = [];
+if ($supplier_id <= 0) {
+    $errors['supplier_id'] = 'Zorunlu';
+}
+if ($full_name === '' || mb_strlen($full_name) < 3 || mb_strlen($full_name) > 120) {
+    $errors['full_name'] = '3-120 karakter olmalı';
+}
+if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $errors['email'] = 'Geçersiz e-posta';
+}
+if ($phone !== '' && mb_strlen($phone) > 25) {
+    $errors['phone'] = 'En fazla 25 karakter';
+}
+if ($is_primary !== 0 && $is_primary !== 1) {
+    $errors['is_primary'] = '0 veya 1 olmalı';
+}
+if ($is_active !== 0 && $is_active !== 1) {
+    $errors['is_active'] = '0 veya 1 olmalı';
+}
+if ($errors) {
+    json_exit(false, 'Doğrulama hatası', ['errors' => $errors]);
+}
+
+try {
+    if ($is_primary) {
+        $stmt = $conn->prepare('UPDATE supplier_contacts SET is_primary=0 WHERE supplier_id=?');
+        $stmt->bind_param('i', $supplier_id);
+        $stmt->execute();
+        $stmt->close();
+    }
+    if ($id > 0) {
+        $stmt = $conn->prepare('UPDATE supplier_contacts SET supplier_id=?, full_name=?, role=?, phone=?, email=?, notes=?, is_primary=?, is_active=? WHERE id=?');
+        $stmt->bind_param('isssssiii', $supplier_id, $full_name, $role, $phone, $email, $notes, $is_primary, $is_active, $id);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        $stmt = $conn->prepare('INSERT INTO supplier_contacts (supplier_id, full_name, role, phone, email, notes, is_primary, is_active) VALUES (?,?,?,?,?,?,?,?)');
+        $stmt->bind_param('isssssii', $supplier_id, $full_name, $role, $phone, $email, $notes, $is_primary, $is_active);
+        $stmt->execute();
+        $id = $stmt->insert_id;
+        $stmt->close();
+    }
+    json_exit(true, 'Kaydedildi', ['id' => $id]);
+} catch (Throwable $e) {
+    json_exit(false, 'Beklenmeyen hata');
+}

--- a/api/suppliers/delete.php
+++ b/api/suppliers/delete.php
@@ -1,0 +1,26 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+session_start();
+header('Content-Type: application/json');
+
+function json_exit($ok, $message = '') {
+    echo json_encode(['ok' => $ok, 'message' => $message]);
+    exit;
+}
+
+$csrf = $_POST['csrf'] ?? '';
+if ($csrf === '' || !isset($_SESSION['csrf_token']) || $csrf !== $_SESSION['csrf_token']) {
+    json_exit(false, 'Geçersiz oturum');
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if ($id <= 0) {
+    json_exit(false, 'Geçersiz ID');
+}
+
+$stmt = $conn->prepare('UPDATE suppliers SET is_active=0 WHERE id=?');
+$stmt->bind_param('i', $id);
+$ok = $stmt->execute();
+$stmt->close();
+
+json_exit($ok, $ok ? 'Silindi' : 'Silinemedi');

--- a/api/suppliers/list.php
+++ b/api/suppliers/list.php
@@ -1,0 +1,57 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+session_start();
+header('Content-Type: application/json');
+
+function json_exit($ok, $data = null, $message = '') {
+    echo json_encode(['ok' => $ok, 'data' => $data, 'message' => $message]);
+    exit;
+}
+
+$q = trim($_GET['q'] ?? '');
+$is_active = $_GET['is_active'] ?? '';
+$page = max(1, (int)($_GET['page'] ?? 1));
+$per_page = max(1, min(100, (int)($_GET['per_page'] ?? 10)));
+$offset = ($page - 1) * $per_page;
+
+$where = ' WHERE 1=1 ';
+$params = [];
+$types = '';
+if ($q !== '') {
+    $where .= ' AND (name LIKE ? OR email LIKE ? OR tax_no LIKE ?)';
+    $like = '%' . $q . '%';
+    $params[] = $like; $params[] = $like; $params[] = $like;
+    $types .= 'sss';
+}
+if ($is_active !== '' && ($is_active === '0' || $is_active === '1')) {
+    $where .= ' AND is_active = ?';
+    $params[] = $is_active; $types .= 'i';
+}
+
+$total = 0;
+$sqlTotal = 'SELECT COUNT(*) FROM suppliers' . $where;
+$stmt = $conn->prepare($sqlTotal);
+if ($types !== '') {
+    $stmt->bind_param($types, ...$params);
+}
+$stmt->execute();
+$stmt->bind_result($total);
+$stmt->fetch();
+$stmt->close();
+
+$sql = 'SELECT s.*, (
+            SELECT COUNT(*) FROM supplier_contacts c 
+            WHERE c.supplier_id = s.id AND c.is_active = 1
+        ) AS contact_count
+        FROM suppliers s' . $where . ' ORDER BY s.name ASC LIMIT ?, ?';
+$params2 = $params;
+$types2 = $types . 'ii';
+$params2[] = $offset; $params2[] = $per_page;
+$stmt = $conn->prepare($sql);
+$stmt->bind_param($types2, ...$params2);
+$stmt->execute();
+$result = $stmt->get_result();
+$rows = $result->fetch_all(MYSQLI_ASSOC);
+$stmt->close();
+
+json_exit(true, ['rows' => $rows, 'total' => $total]);

--- a/api/suppliers/save.php
+++ b/api/suppliers/save.php
@@ -1,0 +1,75 @@
+<?php
+require_once __DIR__ . '/../../config.php';
+session_start();
+header('Content-Type: application/json');
+
+function json_exit($ok, $message = '', $extra = []) {
+    echo json_encode(array_merge(['ok' => $ok, 'message' => $message], $extra));
+    exit;
+}
+
+$csrf = $_POST['csrf'] ?? '';
+if ($csrf === '' || !isset($_SESSION['csrf_token']) || $csrf !== $_SESSION['csrf_token']) {
+    json_exit(false, 'Geçersiz oturum');
+}
+
+$id = (int)($_POST['id'] ?? 0);
+$name = trim($_POST['name'] ?? '');
+$address = trim($_POST['address'] ?? '');
+$email = trim($_POST['email'] ?? '');
+$tax_no = trim($_POST['tax_no'] ?? '');
+$notes = trim($_POST['notes'] ?? '');
+$is_active = isset($_POST['is_active']) ? 1 : 0;
+
+$errors = [];
+if ($name === '' || mb_strlen($name) < 3 || mb_strlen($name) > 150) {
+    $errors['name'] = '3-150 karakter olmalı';
+}
+if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) {
+    $errors['email'] = 'Geçersiz e-posta';
+}
+if ($tax_no !== '' && !preg_match('/^[A-Z0-9 \/-]+$/i', $tax_no)) {
+    $errors['tax_no'] = 'Geçersiz format';
+}
+if ($is_active !== 0 && $is_active !== 1) {
+    $errors['is_active'] = '0 veya 1 olmalı';
+}
+if ($errors) {
+    json_exit(false, 'Doğrulama hatası', ['errors' => $errors]);
+}
+
+try {
+    if ($id > 0) {
+        $stmt = $conn->prepare('SELECT COUNT(*) FROM suppliers WHERE name=? AND id<>?');
+        $stmt->bind_param('si', $name, $id);
+        $stmt->execute();
+        $stmt->bind_result($count);
+        $stmt->fetch();
+        $stmt->close();
+        if ($count > 0) {
+            json_exit(false, 'Aynı isimde firma mevcut', ['errors' => ['name' => 'Benzersiz olmalı']]);
+        }
+        $stmt = $conn->prepare('UPDATE suppliers SET name=?, address=?, email=?, tax_no=?, notes=?, is_active=? WHERE id=?');
+        $stmt->bind_param('ssssssi', $name, $address, $email, $tax_no, $notes, $is_active, $id);
+        $stmt->execute();
+        $stmt->close();
+    } else {
+        $stmt = $conn->prepare('SELECT COUNT(*) FROM suppliers WHERE name=?');
+        $stmt->bind_param('s', $name);
+        $stmt->execute();
+        $stmt->bind_result($count);
+        $stmt->fetch();
+        $stmt->close();
+        if ($count > 0) {
+            json_exit(false, 'Aynı isimde firma mevcut', ['errors' => ['name' => 'Benzersiz olmalı']]);
+        }
+        $stmt = $conn->prepare('INSERT INTO suppliers (name, address, email, tax_no, notes, is_active) VALUES (?,?,?,?,?,?)');
+        $stmt->bind_param('sssssi', $name, $address, $email, $tax_no, $notes, $is_active);
+        $stmt->execute();
+        $id = $stmt->insert_id;
+        $stmt->close();
+    }
+    json_exit(true, 'Kaydedildi', ['id' => $id]);
+} catch (Throwable $e) {
+    json_exit(false, 'Beklenmeyen hata');
+}

--- a/suppliers.sql
+++ b/suppliers.sql
@@ -1,0 +1,29 @@
+CREATE TABLE suppliers (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  name VARCHAR(150) NOT NULL,
+  address VARCHAR(255) NULL,
+  email VARCHAR(190) NULL,
+  tax_no VARCHAR(50) NULL,
+  notes TEXT NULL,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_by INT NULL,
+  UNIQUE KEY uq_suppliers_name (name),
+  KEY idx_suppliers_active (is_active)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+CREATE TABLE supplier_contacts (
+  id INT AUTO_INCREMENT PRIMARY KEY,
+  supplier_id INT NOT NULL,
+  full_name VARCHAR(120) NOT NULL,
+  role VARCHAR(80) NOT NULL DEFAULT 'Satın Alma Görevlisi',
+  phone VARCHAR(40) NULL,
+  email VARCHAR(190) NULL,
+  notes VARCHAR(255) NULL,
+  is_primary TINYINT(1) NOT NULL DEFAULT 0,
+  is_active TINYINT(1) NOT NULL DEFAULT 1,
+  created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  KEY idx_contacts_supplier (supplier_id),
+  KEY idx_contacts_active (is_active),
+  CONSTRAINT fk_contacts_supplier FOREIGN KEY (supplier_id) REFERENCES suppliers(id) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;

--- a/tedarikciler.php
+++ b/tedarikciler.php
@@ -1,0 +1,198 @@
+<?php
+require_once 'header.php';
+?>
+<div class="container-fluid">
+  <div class="d-flex align-items-center justify-content-between mb-3">
+    <h1 class="h4 mb-0">Tedarikçiler</h1>
+    <div>
+      <button class="btn btn-primary" data-bs-toggle="modal" data-bs-target="#supplierModal">Yeni Tedarikçi</button>
+    </div>
+  </div>
+
+  <div class="card">
+    <div class="card-body">
+      <form id="filterForm" class="row g-2 mb-3">
+        <div class="col-md-4"><input type="text" class="form-control" name="q" placeholder="Firma adı / vergi no / e-posta"></div>
+        <div class="col-md-3">
+          <select class="form-select" name="is_active">
+            <option value="">Tümü (Aktif+Pasif)</option>
+            <option value="1" selected>Aktif</option>
+            <option value="0">Pasif</option>
+          </select>
+        </div>
+        <div class="col-md-2"><button class="btn btn-outline-primary w-100" id="btnSearch">Ara</button></div>
+      </form>
+
+      <div class="table-responsive">
+        <table class="table table-hover align-middle" id="tblSuppliers">
+          <thead>
+            <tr><th>Firma Adı</th><th>Adres</th><th>E-posta</th><th>Vergi No</th><th>Durum</th><th>Kişiler</th><th class="text-end">İşlemler</th></tr>
+          </thead>
+          <tbody></tbody>
+        </table>
+      </div>
+      <nav><ul class="pagination justify-content-end" id="pager"></ul></nav>
+    </div>
+  </div>
+</div>
+
+<!-- Firma Modal -->
+<div class="modal fade" id="supplierModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content" id="frmSupplier">
+      <div class="modal-header"><h5 class="modal-title">Tedarikçi</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+      <div class="modal-body">
+        <input type="hidden" name="id"><input type="hidden" name="csrf" value="<?= htmlspecialchars($_SESSION['csrf_token']) ?>">
+        <div class="mb-2"><label class="form-label">Firma Adı *</label><input class="form-control" name="name" required></div>
+        <div class="mb-2"><label class="form-label">Adres</label><input class="form-control" name="address"></div>
+        <div class="mb-2"><label class="form-label">E-posta</label><input class="form-control" name="email" type="email"></div>
+        <div class="mb-2"><label class="form-label">Vergi No</label><input class="form-control" name="tax_no"></div>
+        <div class="mb-2"><label class="form-label">Notlar</label><textarea class="form-control" name="notes" rows="3"></textarea></div>
+        <div class="form-check"><input class="form-check-input" type="checkbox" name="is_active" value="1" checked id="chkActive"><label class="form-check-label" for="chkActive">Aktif</label></div>
+      </div>
+      <div class="modal-footer"><button class="btn btn-secondary" data-bs-dismiss="modal" type="button">Kapat</button><button class="btn btn-primary" id="btnSaveSupplier">Kaydet</button></div>
+    </form>
+  </div>
+</div>
+
+<!-- Kişiler Offcanvas -->
+<div class="offcanvas offcanvas-end" tabindex="-1" id="contactsPanel">
+  <div class="offcanvas-header"><h5 class="offcanvas-title">Firma Kişileri</h5><button type="button" class="btn-close" data-bs-dismiss="offcanvas"></button></div>
+  <div class="offcanvas-body">
+    <div class="d-flex justify-content-end mb-2"><button class="btn btn-primary" id="btnNewContact">Yeni Kişi</button></div>
+    <table class="table table-sm" id="tblContacts"><thead><tr><th>Ad Soyad</th><th>Rol</th><th>Telefon</th><th>E-posta</th><th>Birincil</th><th></th></tr></thead><tbody></tbody></table>
+  </div>
+</div>
+
+<!-- Kişi Modal -->
+<div class="modal fade" id="contactModal" tabindex="-1">
+  <div class="modal-dialog">
+    <form class="modal-content" id="frmContact">
+      <div class="modal-header"><h5 class="modal-title">Kişi</h5><button type="button" class="btn-close" data-bs-dismiss="modal"></button></div>
+      <div class="modal-body">
+        <input type="hidden" name="id"><input type="hidden" name="supplier_id"><input type="hidden" name="csrf" value="<?= htmlspecialchars($_SESSION['csrf_token']) ?>">
+        <div class="mb-2"><label class="form-label">Ad Soyad *</label><input class="form-control" name="full_name" required></div>
+        <div class="mb-2"><label class="form-label">Rol</label><input class="form-control" name="role"></div>
+        <div class="mb-2"><label class="form-label">Telefon</label><input class="form-control" name="phone"></div>
+        <div class="mb-2"><label class="form-label">E-posta</label><input class="form-control" name="email" type="email"></div>
+        <div class="mb-2"><label class="form-label">Notlar</label><input class="form-control" name="notes"></div>
+        <div class="form-check mb-2"><input class="form-check-input" type="checkbox" name="is_primary" value="1" id="chkPrimary"><label class="form-check-label" for="chkPrimary">Birincil</label></div>
+        <div class="form-check"><input class="form-check-input" type="checkbox" name="is_active" value="1" checked id="chkContactActive"><label class="form-check-label" for="chkContactActive">Aktif</label></div>
+      </div>
+      <div class="modal-footer"><button class="btn btn-secondary" data-bs-dismiss="modal" type="button">Kapat</button><button class="btn btn-primary" id="btnSaveContact">Kaydet</button></div>
+    </form>
+  </div>
+</div>
+
+</div>
+<!-- main-content close -->
+
+<script>
+const tblSuppliers=document.querySelector('#tblSuppliers tbody');
+const filterForm=document.getElementById('filterForm');
+const supplierModal=new bootstrap.Modal(document.getElementById('supplierModal'));
+const contactPanel=new bootstrap.Offcanvas(document.getElementById('contactsPanel'));
+const contactModal=new bootstrap.Modal(document.getElementById('contactModal'));
+let currentSupplierId=0;
+
+function loadSuppliers(page=1){
+  const fd=new FormData(filterForm);fd.append('page',page);
+  fetch('api/suppliers/list.php?'+new URLSearchParams(fd).toString())
+    .then(r=>r.json()).then(res=>{
+      tblSuppliers.innerHTML='';
+      res.data.rows.forEach(r=>{
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${r.name}</td><td>${r.address||''}</td><td>${r.email||''}</td><td>${r.tax_no||''}</td>`+
+          `<td><span class="badge ${r.is_active==1?'bg-success':'bg-secondary'}">${r.is_active==1?'Aktif':'Pasif'}</span></td>`+
+          `<td><span class=\"badge bg-info text-dark\">${r.contact_count}</span></td>`+
+          `<td class='text-end'><button class='btn btn-sm btn-outline-secondary me-1' onclick='editSupplier(${r.id})'>Düzenle</button>`+
+          `<button class='btn btn-sm btn-outline-primary me-1' onclick='showContacts(${r.id})'>Kişiler</button>`+
+          `<button class='btn btn-sm btn-outline-danger' onclick='deleteSupplier(${r.id})'>Sil</button></td>`;
+        tblSuppliers.appendChild(tr);
+      });
+    });
+}
+
+filterForm.addEventListener('submit',e=>{e.preventDefault();loadSuppliers();});
+loadSuppliers();
+
+function editSupplier(id){
+  fetch('api/suppliers/list.php?id='+id).then(r=>r.json()).then(res=>{
+    const s=res.data.rows.find(x=>x.id==id);if(!s)return;
+    const f=document.getElementById('frmSupplier');
+    for(const k in s){if(f[k])f[k].value=s[k];}
+    f.is_active.checked=s.is_active==1;
+    supplierModal.show();
+  });
+}
+
+function deleteSupplier(id){
+  if(!confirm('Silinsin mi?'))return;
+  fetch('api/suppliers/delete.php',{method:'POST',body:new URLSearchParams({id:id,csrf:'<?= $_SESSION['csrf_token'] ?>'})})
+    .then(r=>r.json()).then(()=>loadSuppliers());
+}
+
+function showContacts(supplierId){
+  currentSupplierId=supplierId;
+  document.querySelector('#frmContact [name=supplier_id]').value=supplierId;
+  loadContacts();
+  contactPanel.show();
+}
+
+function loadContacts(){
+  fetch('api/contacts/list.php?supplier_id='+currentSupplierId)
+    .then(r=>r.json()).then(res=>{
+      const tbody=document.querySelector('#tblContacts tbody');
+      tbody.innerHTML='';
+      res.data.rows.forEach(r=>{
+        const tr=document.createElement('tr');
+        tr.innerHTML=`<td>${r.full_name}</td><td>${r.role||''}</td><td>${r.phone||''}</td><td>${r.email||''}</td>`+
+          `<td>${r.is_primary==1?'Evet':'Hayır'}</td>`+
+          `<td class='text-end'><button class='btn btn-sm btn-outline-secondary me-1' onclick='editContact(${r.id})'>Düzenle</button>`+
+          `<button class='btn btn-sm btn-outline-danger' onclick='deleteContact(${r.id})'>Sil</button></td>`;
+        tbody.appendChild(tr);
+      });
+    });
+}
+
+document.getElementById('btnNewContact').addEventListener('click',()=>{
+  document.getElementById('frmContact').reset();
+  document.querySelector('#frmContact [name=id]').value='';
+  contactModal.show();
+});
+
+document.getElementById('frmSupplier').addEventListener('submit',e=>{
+  e.preventDefault();
+  const fd=new FormData(e.target);
+  fetch('api/suppliers/save.php',{method:'POST',body:fd})
+    .then(r=>r.json()).then(res=>{if(res.ok){supplierModal.hide();loadSuppliers();}});
+});
+
+document.getElementById('frmContact').addEventListener('submit',e=>{
+  e.preventDefault();
+  const fd=new FormData(e.target);
+  fetch('api/contacts/save.php',{method:'POST',body:fd})
+    .then(r=>r.json()).then(res=>{if(res.ok){contactModal.hide();loadContacts();loadSuppliers();}});
+});
+
+function editContact(id){
+  fetch('api/contacts/list.php?supplier_id='+currentSupplierId)
+    .then(r=>r.json()).then(res=>{
+      const c=res.data.rows.find(x=>x.id==id);if(!c)return;
+      const f=document.getElementById('frmContact');
+      for(const k in c){if(f[k])f[k].value=c[k];}
+      f.is_primary.checked=c.is_primary==1;f.is_active.checked=c.is_active==1;
+      contactModal.show();
+    });
+}
+
+function deleteContact(id){
+  if(!confirm('Silinsin mi?'))return;
+  fetch('api/contacts/delete.php',{method:'POST',body:new URLSearchParams({id:id,csrf:'<?= $_SESSION['csrf_token'] ?>'})})
+    .then(r=>r.json()).then(()=>{loadContacts();loadSuppliers();});
+}
+</script>
+
+<script src='https://cdn.jsdelivr.net/npm/bootstrap@5.3.0/dist/js/bootstrap.bundle.min.js'></script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Implement supplier CRUD and contact management endpoints.
- Add tedarikciler page with Bootstrap UI for suppliers and their contacts.
- Provide SQL schema for suppliers and supplier contacts.

## Testing
- `php -l api/suppliers/list.php`
- `php -l api/suppliers/save.php`
- `php -l api/suppliers/delete.php`
- `php -l api/contacts/list.php`
- `php -l api/contacts/save.php`
- `php -l api/contacts/delete.php`
- `php -l tedarikciler.php`


------
https://chatgpt.com/codex/tasks/task_e_68bade04da3083289af399b79ed2a3b0