### PR TITLE
Wrap pages with content container for sidebar

### DIFF
--- a/dashboard.php
+++ b/dashboard.php
@@ -280,7 +280,7 @@ foreach ($orders as $o) {
     }
 </style>
 
-<div class="content container">
+<div class="content container-fluid">
     <h1 class='page-title'>
         <i class='fas fa-tachometer-alt me-3'></i>
         Panel Özeti

--- a/tedarikciler.php
+++ b/tedarikciler.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'header.php';
 ?>
-<div class="container-fluid">
+<div class="content container-fluid">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h1 class="h4 mb-0">Tedarikçiler</h1>
     <div>


### PR DESCRIPTION
## Summary
- Ensure dashboard uses a `content` container compatible with sidebar layout
- Wrap suppliers page in `content` container for consistent sidebar spacing

## Testing
- `php -l dashboard.php`
- `php -l tedarikciler.php`


------
https://chatgpt.com/codex/tasks/task_e_68badfd07e488328999c7098a7bec6d1