### PR TITLE
Use container layout for supplier page

### DIFF
--- a/tedarikciler.php
+++ b/tedarikciler.php
@@ -1,7 +1,7 @@
 <?php
 require_once 'header.php';
 ?>
-<div class="container-fluid">
+<div class="container">
   <div class="d-flex align-items-center justify-content-between mb-3">
     <h1 class="h4 mb-0">Tedarikçiler</h1>
     <div>


### PR DESCRIPTION
## Summary
- replace `.container-fluid` with `.container` in suppliers page to use fixed-width container

## Testing
- `php -l tedarikciler.php`


------
https://chatgpt.com/codex/tasks/task_e_68bae275a824832893a6dbe45bb0fb05