### PR TITLE
Add supplier contacts API endpoints

### DIFF
--- a/api/supplier_contacts/delete.php
+++ b/api/supplier_contacts/delete.php
@@ -1,0 +1,26 @@
+<?php
+require_once '../../includes/bootstrap.php';
+require_login();
+
+if (!csrf_verify($_POST['csrf'] ?? '')) {
+  json_exit(false, 'Geçersiz oturum (CSRF)');
+}
+
+$id = (int)($_POST['id'] ?? 0);
+if ($id <= 0) json_exit(false, 'id gerekli');
+
+try {
+  // SOFT DELETE tercih ediyorsan:
+  // $stmt = $pdo->prepare('UPDATE supplier_contacts SET is_active=0 WHERE id=?');
+  // $stmt->execute([$id]);
+
+  // HARD DELETE:
+  $stmt = $pdo->prepare('DELETE FROM supplier_contacts WHERE id=?');
+  $stmt->execute([$id]);
+
+  if ($stmt->rowCount() === 0) json_exit(false, 'Kayıt bulunamadı');
+
+  json_exit(true, 'Silindi');
+} catch (Throwable $e) {
+  json_exit(false, 'Beklenmeyen hata');
+}

--- a/api/supplier_contacts/get.php
+++ b/api/supplier_contacts/get.php
@@ -1,0 +1,14 @@
+<?php
+require_once '../../includes/bootstrap.php';
+require_login();
+
+$id = (int)($_GET['id'] ?? 0);
+if ($id <= 0) json_exit(false, 'id gerekli');
+
+$stmt = $pdo->prepare("SELECT id, supplier_id, full_name, role, phone, email, notes, is_primary, is_active, created_at
+                       FROM supplier_contacts WHERE id = ?");
+$stmt->execute([$id]);
+$row = $stmt->fetch(PDO::FETCH_ASSOC);
+if (!$row) json_exit(false, 'Kayıt bulunamadı');
+
+json_exit(true, 'OK', ['row' => $row]);

--- a/api/supplier_contacts/list.php
+++ b/api/supplier_contacts/list.php
@@ -1,0 +1,47 @@
+<?php
+require_once '../../includes/bootstrap.php';
+require_login();
+
+$supplier_id = (int)($_GET['supplier_id'] ?? 0);
+if ($supplier_id <= 0) json_exit(false, 'supplier_id gerekli');
+
+$q         = trim($_GET['q'] ?? '');
+$is_active = $_GET['is_active'] ?? '';
+$page      = max(1, (int)($_GET['page'] ?? 1));
+$per_page  = min(100, max(5, (int)($_GET['per_page'] ?? 10)));
+$offset    = ($page - 1) * $per_page;
+
+$where = ['supplier_id = :sid'];
+$params = ['sid' => $supplier_id];
+
+if ($q !== '') {
+  $where[] = '(full_name LIKE :q OR email LIKE :q OR phone LIKE :q)';
+  $params['q'] = "%{$q}%";
+}
+if ($is_active !== '' && in_array($is_active, ['0','1'], true)) {
+  $where[] = 'is_active = :act';
+  $params['act'] = (int)$is_active;
+}
+
+$whereSql = $where ? ('WHERE '.implode(' AND ', $where)) : '';
+
+$countSql = "SELECT COUNT(*) FROM supplier_contacts {$whereSql}";
+$stmt = $pdo->prepare($countSql);
+$stmt->execute($params);
+$total = (int)$stmt->fetchColumn();
+
+$sql = "SELECT id, supplier_id, full_name, role, phone, email, notes, is_primary, is_active, created_at
+        FROM supplier_contacts
+        {$whereSql}
+        ORDER BY is_primary DESC, full_name ASC
+        LIMIT :limit OFFSET :offset";
+$stmt = $pdo->prepare($sql);
+foreach ($params as $k => $v) {
+  $stmt->bindValue(":{$k}", $v);
+}
+$stmt->bindValue(':limit',  $per_page, PDO::PARAM_INT);
+$stmt->bindValue(':offset', $offset,   PDO::PARAM_INT);
+$stmt->execute();
+$rows = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+json_exit(true, 'OK', ['rows' => $rows, 'total' => $total, 'page' => $page, 'per_page' => $per_page]);

--- a/api/supplier_contacts/save.php
+++ b/api/supplier_contacts/save.php
@@ -1,0 +1,68 @@
+<?php
+require_once '../../includes/bootstrap.php';
+require_login();
+
+if (!csrf_verify($_POST['csrf'] ?? '')) {
+  json_exit(false, 'Geçersiz oturum (CSRF)');
+}
+
+$id          = (int)($_POST['id'] ?? 0);
+$supplier_id = (int)($_POST['supplier_id'] ?? 0);
+$full_name   = trim($_POST['full_name'] ?? '');
+$role        = trim($_POST['role'] ?? 'Satın Alma Görevlisi');
+$phone       = trim($_POST['phone'] ?? '');
+$email       = trim($_POST['email'] ?? '');
+$notes       = trim($_POST['notes'] ?? '');
+$is_primary  = isset($_POST['is_primary']) && (int)$_POST['is_primary'] === 1 ? 1 : 0;
+$is_active   = isset($_POST['is_active'])  && (int)$_POST['is_active']  === 0 ? 0 : 1;
+
+$errors = [];
+if ($supplier_id <= 0) $errors['supplier_id'] = 'Geçersiz supplier_id';
+if ($full_name === '' || mb_strlen($full_name) < 3) $errors['full_name'] = 'En az 3 karakter';
+if ($email !== '' && !filter_var($email, FILTER_VALIDATE_EMAIL)) $errors['email'] = 'Geçersiz e-posta';
+if ($errors) json_exit(false, 'Doğrulama hatası', ['errors' => $errors]);
+
+try {
+  $pdo->beginTransaction();
+
+  // supplier var mı?
+  $chk = $pdo->prepare('SELECT id FROM suppliers WHERE id = ?');
+  $chk->execute([$supplier_id]);
+  if (!$chk->fetchColumn()) {
+    $pdo->rollBack();
+    json_exit(false, 'Tedarikçi bulunamadı', ['errors' => ['supplier_id' => 'Mevcut değil']]);
+  }
+
+  // is_primary = 1 ise aynı firmadaki diğer birincilleri sıfırla
+  if ($is_primary === 1) {
+    $sqlReset = 'UPDATE supplier_contacts SET is_primary = 0 WHERE supplier_id = ?';
+    if ($id > 0) $sqlReset .= ' AND id <> ?';
+    $stmt = $pdo->prepare($sqlReset);
+    $id > 0 ? $stmt->execute([$supplier_id, $id]) : $stmt->execute([$supplier_id]);
+  }
+
+  if ($id > 0) {
+    // güncelle
+    $stmt = $pdo->prepare('UPDATE supplier_contacts
+                           SET full_name=?, role=?, phone=?, email=?, notes=?, is_primary=?, is_active=?
+                           WHERE id=? AND supplier_id=?');
+    $ok = $stmt->execute([$full_name, $role, $phone, $email, $notes, $is_primary, $is_active, $id, $supplier_id]);
+    if (!$ok || $stmt->rowCount() === 0) {
+      $pdo->rollBack();
+      json_exit(false, 'Güncellenecek kayıt bulunamadı');
+    }
+  } else {
+    // ekle
+    $stmt = $pdo->prepare('INSERT INTO supplier_contacts
+      (supplier_id, full_name, role, phone, email, notes, is_primary, is_active)
+      VALUES (?,?,?,?,?,?,?,?)');
+    $stmt->execute([$supplier_id, $full_name, $role, $phone, $email, $notes, $is_primary, $is_active]);
+    $id = (int)$pdo->lastInsertId();
+  }
+
+  $pdo->commit();
+  json_exit(true, 'Kaydedildi', ['id' => $id]);
+} catch (Throwable $e) {
+  if ($pdo->inTransaction()) $pdo->rollBack();
+  json_exit(false, 'Beklenmeyen hata');
+}


### PR DESCRIPTION
## Summary
- implement CRUD-style endpoints for supplier contacts

## Testing
- `php -l api/supplier_contacts/list.php`
- `php -l api/supplier_contacts/get.php`
- `php -l api/supplier_contacts/save.php`
- `php -l api/supplier_contacts/delete.php`


------
https://chatgpt.com/codex/tasks/task_e_68baecf882308328b51e18122af8fc9e